### PR TITLE
Add fillCartesianReferencePolyline() sampling the reference line only

### DIFF
--- a/include/corridor/corridor.h
+++ b/include/corridor/corridor.h
@@ -106,6 +106,10 @@ class Corridor {
   // Introspection
   friend std::ostream& operator<<(std::ostream& os, const Corridor& corridor);
 
+  void fillCartesianReferencePolyline(
+      CartesianPoints2D* reference_polyline, const RealType delta_l,
+      const bool sample_boundaries) const noexcept;
+
   void fillCartesianPolylines(
       CartesianPoints2D* reference_line, CartesianPoints2D* left_boundary,
       CartesianPoints2D* right_boundary, const RealType delta_l = 0.1,

--- a/src/corridor.cpp
+++ b/src/corridor.cpp
@@ -159,6 +159,13 @@ std::ostream& operator<<(std::ostream& os, const Corridor& corridor) {
   return os;
 }
 
+void Corridor::fillCartesianReferencePolyline(
+    CartesianPoints2D* reference_polyline, const RealType delta_l,
+    const bool sample_boundaries) const noexcept {
+  // Sample reference line
+  reference_line_.fillCartesianPolyline(reference_polyline, delta_l);
+}
+
 void Corridor::fillCartesianPolylines(
     CartesianPoints2D* reference_polyline, CartesianPoints2D* left_polyline,
     CartesianPoints2D* right_polyline, const RealType delta_l,


### PR DESCRIPTION
Following #1 I added a small utility function to sample the reference line.
Compared to `fillCartesianPolylines()` it doesn't care about the bounds.