### PR TITLE
Avoid unnecessary reallocations by calling `vector::reserve()` when appropriate

### DIFF
--- a/src/corridor.cpp
+++ b/src/corridor.cpp
@@ -24,6 +24,12 @@ void SampleAllPolylines(const cubic_spline::CubicSpline& reference_line,
 
   RealType query_l = 0.0;
   RealType max_length = reference_line.GetTotalLength();
+  const auto num_pts = std::ceil(max_length / delta_l) + 1;
+
+  reference_polyline->reserve(num_pts);
+  left_polyline->reserve(num_pts);
+  right_polyline->reserve(num_pts);
+
   while (query_l <= max_length) {
     const CartesianPoint2D position = reference_line.GetPositionAt(query_l);
     const CartesianVector2D normal = reference_line.GetNormalVectorAt(query_l);
@@ -55,6 +61,8 @@ void FillBoundaryPolyline(const cubic_spline::CubicSpline& reference_line,
                           const FrenetPolyline& boundary,
                           CartesianPoints2D* boundary_polyline) {
   boundary_polyline->clear();
+  boundary_polyline->reserve(boundary.size());
+
   for (int i = 0, size = boundary.size(); i < size; i++) {
     const FrenetPoint2D frenet_point = boundary[i];
     const CartesianPoint2D position =

--- a/src/cubic_interpolation_2d.cpp
+++ b/src/cubic_interpolation_2d.cpp
@@ -19,6 +19,7 @@ SplineCoefficients2d SplineCoefficientsFromDataMatrix(
     const DataMatrix<RealType>& data) {
   SplineCoefficients2d coefficients;
   coefficients.clear();
+  coefficients.reserve(data.cols());
   for (DataIdx i = 0, max_idx = (data.cols() - 1); i < max_idx; i++) {
     coefficients.emplace_back(Coefficients2d(data.col(i), data.col(i + 1)));
   }

--- a/src/cubic_spline.cpp
+++ b/src/cubic_spline.cpp
@@ -120,12 +120,15 @@ void CubicSpline::fillCartesianPolyline(CartesianPoints2D* polyline,
                                         const RealType delta_l) const {
   polyline->clear();
   if (delta_l <= 0.0) {
+    polyline->reserve(data_.cols());
     for (int idx = 0; idx < data_.cols(); idx++) {
       polyline->emplace_back(data_(kPoint_x, idx), data_(kPoint_y, idx));
     }
   } else {
     RealType query_l = 0.0;
     const RealType max_length = GetTotalLength();
+    const auto num_pts = std::ceil(max_length / delta_l) + 1;
+    polyline->reserve(num_pts);
     while (query_l <= max_length) {
       polyline->emplace_back(GetPositionAt(query_l));
       query_l += delta_l;


### PR DESCRIPTION
Calls `reserve()` with expected vector length, before filling the vector. This prevents memory reallocations and copying during `emplace_back()` and such.

I didn't look through all your code, only threw it in whenever there was a `clear()`. So I might have missed some spots (e.g. when you create new vectors.)