### PR TITLE
Fix velocity conversion from frenet to cartesian

### DIFF
--- a/include/corridor/frenet_types.h
+++ b/include/corridor/frenet_types.h
@@ -131,6 +131,8 @@ class FrenetFrame2D {
 
   CartesianVector2D FromFrenetVector(const FrenetVector2D& frenet_vector) const;
 
+  CartesianVector2D FromRelativeFrenetVector(const FrenetVector2D& relative_vector) const;
+
   CartesianState2D FromFrenetState(const FrenetState2D& frenet_state) const;
 
   /**

--- a/src/frenet_types.cpp
+++ b/src/frenet_types.cpp
@@ -24,15 +24,20 @@ CartesianVector2D FrenetFrame2D::FromFrenetVector(
   const FrenetVector2D relative_vector{
       frenet_vector.l() - frenet_base_.arc_length, frenet_vector.d()};
   // Coordination transformation
+  return FromRelativeFrenetVector(relative_vector);
+};
+
+CartesianVector2D FrenetFrame2D::FromRelativeFrenetVector(
+    const FrenetVector2D& relative_vector) const {
+  // Coordination transformation
   return rotMat_F2C_ * relative_vector;
 };
 
 CartesianState2D FrenetFrame2D::FromFrenetState(
     const FrenetState2D& frenet_state) const {
-  // TODO(dsp): add convertion for moving frenet frame assumption
   CartesianStateVector2D cartesian_mean(
       FromFrenetPoint(frenet_state.position()),
-      FromFrenetVector(frenet_state.velocity()));
+      FromRelativeFrenetVector(frenet_state.velocity()));
 
   // 4x4 rotation matrix
   Eigen::Matrix<corridor::RealType, 4, 4> rotation_matrix =


### PR DESCRIPTION
I came across the following bug (which even had a todo comment):

`FromFrenetState` currently calls `FromFrenetVector(frenet_state.velocity());` which does
```cpp
const FrenetVector2D relative_vector{frenet_vector.l() - frenet_base_.arc_length, frenet_vector.d()};
// Coordination transformation
return rotMat_F2C_ * relative_vector;
```
That means it subtracts `frenet_base_.arc_length` from the longitudinal velocity before rotating it, which does not make sense.

This PR fixes this issue by rotating only the velocity vector.